### PR TITLE
Add openSUSE dependencies to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,12 @@ For Arch Linux there is a package available via AUR: https://aur.archlinux.org/p
 * libkf5plasma-dev
 * qt5-default
 * qtdeclarative5-dev
+
+### Dependencies (openSUSE)
+
+* cmake
+* extra-cmake-modules
+* linux-glibc-devel
+* libqt5-qtbase-devel
+
+


### PR DESCRIPTION
On openSuse qmake is hidden in some other package, therefor the specific Suse dependency listing might be useful.